### PR TITLE
Target manager

### DIFF
--- a/Assets/_BowAndArrow/Prefabs/SphericalTarget.prefab
+++ b/Assets/_BowAndArrow/Prefabs/SphericalTarget.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2762203773592475861}
   m_Layer: 0
   m_Name: SphericalTarget
-  m_TagString: Untagged
+  m_TagString: Target
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -47,6 +47,7 @@ GameObject:
   - component: {fileID: 4485088024214343166}
   - component: {fileID: 4485088024214343165}
   - component: {fileID: 4485088024214343142}
+  - component: {fileID: 1499342312087700653}
   m_Layer: 0
   m_Name: Inner
   m_TagString: Untagged
@@ -82,7 +83,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   forceAmount: 100
   otherMaterial: {fileID: 2100000, guid: bc77364cebd5ea84bbdaa7560bccb7d9, type: 2}
-  ascore: 0
+  ascore: 100
   hitTarget: {fileID: 8300000, guid: a332b558cbb4e3442b23e06fb335d1ed, type: 3}
   celebration: {fileID: 0}
 --- !u!33 &4485088024214343167
@@ -163,6 +164,102 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 4
   m_CollisionDetection: 0
+--- !u!82 &1499342312087700653
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4485088024214343156}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &4485088024214343157
 GameObject:
   m_ObjectHideFlags: 0
@@ -177,6 +274,7 @@ GameObject:
   - component: {fileID: 4485088024214343137}
   - component: {fileID: 4485088024214343136}
   - component: {fileID: 4485088024214343160}
+  - component: {fileID: 3209820776647566680}
   m_Layer: 0
   m_Name: Middle
   m_TagString: Untagged
@@ -212,7 +310,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   forceAmount: 100
   otherMaterial: {fileID: 2100000, guid: bc77364cebd5ea84bbdaa7560bccb7d9, type: 2}
-  ascore: 0
+  ascore: 50
   hitTarget: {fileID: 8300000, guid: a332b558cbb4e3442b23e06fb335d1ed, type: 3}
   celebration: {fileID: 0}
 --- !u!33 &4485088024214343138
@@ -293,6 +391,102 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 4
   m_CollisionDetection: 0
+--- !u!82 &3209820776647566680
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4485088024214343157}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &4485088024214343158
 GameObject:
   m_ObjectHideFlags: 0
@@ -307,6 +501,7 @@ GameObject:
   - component: {fileID: 4485088024214343140}
   - component: {fileID: 4485088024214343139}
   - component: {fileID: 4485088024214343161}
+  - component: {fileID: 6308300702471172476}
   m_Layer: 0
   m_Name: Outer
   m_TagString: Untagged
@@ -342,7 +537,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   forceAmount: 100
   otherMaterial: {fileID: 2100000, guid: bc77364cebd5ea84bbdaa7560bccb7d9, type: 2}
-  ascore: 0
+  ascore: 20
   hitTarget: {fileID: 8300000, guid: a332b558cbb4e3442b23e06fb335d1ed, type: 3}
   celebration: {fileID: 0}
 --- !u!33 &4485088024214343141
@@ -423,6 +618,102 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 4
   m_CollisionDetection: 0
+--- !u!82 &6308300702471172476
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4485088024214343158}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &9217671786507258384
 GameObject:
   m_ObjectHideFlags: 0
@@ -466,5 +757,5 @@ SphereCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 3
+  m_Radius: 2.5
   m_Center: {x: 0.48, y: 1.98, z: 4}

--- a/Assets/_BowAndArrow/Scenes/Main.unity
+++ b/Assets/_BowAndArrow/Scenes/Main.unity
@@ -810,8 +810,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 283.06, y: 149}
+  m_SizeDelta: {x: 306.13, y: 58}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &472634450
 MonoBehaviour:
@@ -844,9 +844,9 @@ MonoBehaviour:
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Testing text 2
+  m_Text: 
 --- !u!222 &472634451
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1666,6 +1666,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: SphericalTarget (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2762203773592475860, guid: d2c38afe94b2cdf478c726c122edd9d9,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2762203773592475861, guid: d2c38afe94b2cdf478c726c122edd9d9,
         type: 3}
@@ -2710,6 +2715,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: SphericalTarget (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 2762203773592475860, guid: d2c38afe94b2cdf478c726c122edd9d9,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2762203773592475861, guid: d2c38afe94b2cdf478c726c122edd9d9,
         type: 3}
       propertyPath: m_RootOrder
@@ -3181,6 +3191,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1689598635}
+  - component: {fileID: 1689598636}
   m_Layer: 0
   m_Name: Targets
   m_TagString: Untagged
@@ -3210,6 +3221,23 @@ Transform:
   m_Father: {fileID: 1662864911}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1689598636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689598634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 931c7cb58af0f2146ac31b61d226ce2a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  numberTargetsDesired: 3
+  targetPrefab: {fileID: 2762203773592475860, guid: d2c38afe94b2cdf478c726c122edd9d9,
+    type: 3}
+  yAxisOffset: 1
+  targetDistanceFromPlayer: 0
 --- !u!1 &1702113657
 GameObject:
   m_ObjectHideFlags: 0
@@ -3867,6 +3895,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: SphericalTarget
+      objectReference: {fileID: 0}
+    - target: {fileID: 2762203773592475860, guid: d2c38afe94b2cdf478c726c122edd9d9,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2762203773592475861, guid: d2c38afe94b2cdf478c726c122edd9d9,
         type: 3}

--- a/Assets/_BowAndArrow/Scenes/Main.unity
+++ b/Assets/_BowAndArrow/Scenes/Main.unity
@@ -776,6 +776,85 @@ Transform:
   m_Father: {fileID: 1662864911}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &472634448
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 472634449}
+  - component: {fileID: 472634451}
+  - component: {fileID: 472634450}
+  m_Layer: 5
+  m_Name: Text2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &472634449
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472634448}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 746476502}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &472634450
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472634448}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Testing text 2
+--- !u!222 &472634451
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472634448}
+  m_CullTransparentMesh: 1
 --- !u!1 &642433624 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4485088024214343156, guid: d2c38afe94b2cdf478c726c122edd9d9,
@@ -995,6 +1074,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 979685818}
+  - {fileID: 472634449}
   m_Father: {fileID: 85813207}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/_BowAndArrow/Scripts/TargetManager.cs
+++ b/Assets/_BowAndArrow/Scripts/TargetManager.cs
@@ -1,0 +1,243 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class TargetManager : MonoBehaviour
+{
+    //This script manages the number of targets in play, generation of new targets, and auto-orienting them toward player
+
+    //properties
+    public int numberTargetsDesired;
+    private int numberTargetsCurrent;
+
+    public GameObject targetPrefab;
+    public float yAxisOffset = 1.0f;
+    public float targetDistanceFromPlayer;
+
+    private Text test;
+    private Text test2;
+    private bool[] targetsInQuadrants;
+
+    private void Awake()
+    {
+        //set up debugging text
+        GameObject go = GameObject.Find("Text2");
+        test = go.GetComponent<Text>();
+        GameObject go2 = GameObject.Find("Text");
+        test2 = go2.GetComponent<Text>();
+
+        //boolean array to track which quadrants have targets
+        //using positions 1-4 to match with quadrants (0 will be false or empty)
+        targetsInQuadrants = new bool[5] { false, false, false, false, false };
+
+        
+    }
+    // Start is called before the first frame update
+    void Start()
+    {
+        //generate desired number of targets
+        for (int i = 0; i < numberTargetsDesired; i++)
+        {
+            generateTarget();
+        }
+
+        //debugging function to see what rotation the targets are generated in
+        //testTargetPos();
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        //check to see if targets are hit
+        GameObject[] activeTargets = GameObject.FindGameObjectsWithTag("Target");
+        foreach (GameObject target in activeTargets)
+        {
+
+            Arrow[] arrows = target.GetComponentsInChildren<Arrow>();
+            if (arrows.Length > 0)
+            {
+                //if any arrows are found as children of target, destroy target in 2 seconds
+                destroyTarget(target);
+                Destroy(target);
+                numberTargetsCurrent--;
+
+                //if less than desired number, generate a target
+                if (numberTargetsCurrent < numberTargetsDesired)
+                {
+                    generateTarget();
+                }
+            }
+        }
+    }
+
+    //debugging function
+    private void testTargetPos()
+    {
+        test.text = "";
+        GameObject[] activeTargets = GameObject.FindGameObjectsWithTag("Target");
+        foreach (GameObject target in activeTargets)
+        {
+            Quaternion rot = target.transform.rotation;
+            float rotation = rot.eulerAngles.y;
+            float xVal = target.transform.position.x;
+            float zVal = target.transform.position.z;
+
+            test.text += "; rot=" + rotation;
+        }
+    }
+
+
+    
+
+    private bool generateTarget()
+    {
+        bool targetCreatedSuccessfully = false;
+
+        // choose quadrant to generate for, return random angle from that quadrant's range
+        int angle = findEmptyQuadrant();
+
+        //set target to zero position and rotate it by angle
+        Vector3 startPosition = Vector3.zero;
+        startPosition.Set(0, yAxisOffset, 0);
+
+        // Instantiate target
+        Instantiate(targetPrefab, startPosition, Quaternion.Euler(0, angle, 0));
+        // increase number of active targets
+        numberTargetsCurrent++;
+        targetCreatedSuccessfully = true;
+        //testTargetPos();
+
+        return targetCreatedSuccessfully;
+    }
+
+    private void destroyTarget(GameObject target)
+    {
+        // get rotation for target
+        Quaternion rot = target.transform.rotation;
+        float rotation = rot.eulerAngles.y;
+
+        // compare to find quadrant, set corresponding position in array to false
+        if (rotation >= 0 && rotation<90)
+        {            
+            //quadrant 1
+            targetsInQuadrants[1] = false;
+        }
+        else if (rotation >= 90 && rotation < 180)
+        {
+            //quadrant 2
+            targetsInQuadrants[2] = false;
+        }
+        else if (rotation >= 180 && rotation < 270)
+        {
+            //quadrant 3
+            targetsInQuadrants[3] = false;
+        }
+        else if (rotation >= 270 && rotation < 360)
+        {
+            //quadrant 4
+            targetsInQuadrants[4] = false;
+        }
+    }
+
+    private Vector3 calculateTargetPosition(int angle)
+    {
+        //old function, was used in previous version
+
+
+        Vector3 targetPosition = Vector3.zero;
+
+        float xValue = Mathf.Cos(angle) * targetDistanceFromPlayer;
+        float zValue = Mathf.Sin(angle) * targetDistanceFromPlayer;
+
+        test2.text += "; xValue= " + xValue + "; zValue= " + zValue;
+        targetPosition.Set(xValue, yAxisOffset, zValue);
+        return targetPosition;
+    }
+
+    
+    private float findYRotationAngle2(float xValue, float zValue)
+    {
+        //old function, was used in previous version - not accurate!
+        float angle;
+
+        Vector3 player = Vector3.zero;
+        player.Set(0, yAxisOffset, 0);
+        Vector3 target = Vector3.zero;
+        target.Set(xValue, yAxisOffset, zValue);
+        Vector3 playerDirection = player - target;
+        angle = Vector3.Angle(Vector3.back, playerDirection);
+
+        if (xValue < 0 && zValue > 0) //q2
+        {
+            return (angle *= -1);
+        }
+        else if (xValue > 0 && zValue > 0) //q1
+        {
+            return angle;
+        }
+        else if (xValue < 0 && zValue < 0) //q3
+        {
+            return (angle);
+        }
+        else if (xValue > 0 && zValue < 0) //q4
+        {
+            return -(angle);
+        }
+        else //xValue = 0
+        {
+            return 0.0f;
+        }
+    }
+
+    
+    private int findEmptyQuadrant()
+    {
+        //finds first empty quadrant and returns a random angle in that quadrant
+        int emptyQuadrant = 0;
+
+        for (int i = 1; i < 5; i++)
+        {
+            if (targetsInQuadrants[i] == false)
+            {
+                emptyQuadrant = i;
+                break;
+            }
+        }
+
+        int angle = getRandomAngle(emptyQuadrant);
+        return angle;
+    }
+
+    private int getRandomAngle(int quadrant)
+    {
+        int angle;
+        switch (quadrant)
+        {
+            case 1:
+                angle = Random.Range(0, 90);
+                targetsInQuadrants[1] = true;
+                break;
+            case 2:
+                angle = Random.Range(90, 180);
+                targetsInQuadrants[2] = true;
+                break;
+            case 3:
+                angle = Random.Range(180, 270);
+                targetsInQuadrants[3] = true;
+                break;
+            case 4:
+                angle = Random.Range(270, 360);
+                targetsInQuadrants[4] = true;
+                break;
+            default:
+                //angle = Random.Range(0, 360);
+                angle = 0;
+                break;
+        }
+        
+        test.text += "; q=" + quadrant + "; angle="+angle;
+        return angle;
+    }
+}

--- a/Assets/_BowAndArrow/Scripts/TargetManager.cs
+++ b/Assets/_BowAndArrow/Scripts/TargetManager.cs
@@ -237,7 +237,7 @@ public class TargetManager : MonoBehaviour
                 break;
         }
         
-        test.text += "; q=" + quadrant + "; angle="+angle;
+        //test.text += "; q=" + quadrant + "; angle="+angle;
         return angle;
     }
 }

--- a/Assets/_BowAndArrow/Scripts/TargetManager.cs.meta
+++ b/Assets/_BowAndArrow/Scripts/TargetManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 931c7cb58af0f2146ac31b61d226ce2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Updated prefabs to deal with score and sound (prefabs used now instead of in-scene targets). Added target manager script: targets are now automatically generated in the scene - one in each quadrant (for however many quadrants/targets desired - currently set to 3).